### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,27 @@
 # Changelog
 
-### [0.1.4](https://github.com/googleapis/python-video-live-stream/compare/v0.1.3...v0.1.4) (2022-05-22)
+## [0.1.4](https://github.com/googleapis/python-video-live-stream/compare/v0.1.3...v0.1.4) (2022-05-22)
 
 
 ### Documentation
 
 * updated comments to match API behaviors ([#45](https://github.com/googleapis/python-video-live-stream/issues/45)) ([bdc9463](https://github.com/googleapis/python-video-live-stream/commit/bdc9463156a63439ef41621405394042d01f3cb9))
 
-### [0.1.3](https://github.com/googleapis/python-video-live-stream/compare/v0.1.2...v0.1.3) (2022-05-03)
+## [0.1.3](https://github.com/googleapis/python-video-live-stream/compare/v0.1.2...v0.1.3) (2022-05-03)
 
 
 ### Documentation
 
 * **samples:** add sample for creating a channel with a failover backup input ([#37](https://github.com/googleapis/python-video-live-stream/issues/37)) ([9587382](https://github.com/googleapis/python-video-live-stream/commit/958738237c7c055a3a656ce2c3a7964e49d6b6b1))
 
-### [0.1.2](https://github.com/googleapis/python-video-live-stream/compare/v0.1.1...v0.1.2) (2022-04-28)
+## [0.1.2](https://github.com/googleapis/python-video-live-stream/compare/v0.1.1...v0.1.2) (2022-04-28)
 
 
 ### Documentation
 
 * **samples:** add code samples ([#21](https://github.com/googleapis/python-video-live-stream/issues/21)) ([484271d](https://github.com/googleapis/python-video-live-stream/commit/484271de8790e2d9d0d4ea02feb344398317ffe5))
 
-### [0.1.1](https://github.com/googleapis/python-video-live-stream/compare/v0.1.0...v0.1.1) (2022-03-05)
+## [0.1.1](https://github.com/googleapis/python-video-live-stream/compare/v0.1.0...v0.1.1) (2022-03-05)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.